### PR TITLE
feat(keto-client-wrapper): add publicBasePath option 

### DIFF
--- a/packages/keto-client-wrapper/src/lib/ory-relationships/ory-relationships.interfaces.ts
+++ b/packages/keto-client-wrapper/src/lib/ory-relationships/ory-relationships.interfaces.ts
@@ -8,6 +8,7 @@ import {
 
 export interface IOryRelationshipsModuleOptions extends OryBaseModuleOptions {
   basePath: string;
+  publicBasePath?: string;
   accessToken?: string;
 }
 
@@ -16,10 +17,12 @@ export class OryRelationshipsModuleOptions
   implements IOryRelationshipsModuleOptions
 {
   basePath: string;
+  publicBasePath?: string;
   accessToken?: string;
   constructor(options: IOryRelationshipsModuleOptions) {
     super(options);
     this.basePath = options.basePath;
+    this.publicBasePath = options.publicBasePath;
     this.accessToken = options.accessToken;
   }
 }

--- a/packages/keto-client-wrapper/src/lib/ory-relationships/ory-relationships.service.ts
+++ b/packages/keto-client-wrapper/src/lib/ory-relationships/ory-relationships.service.ts
@@ -1,11 +1,18 @@
 import { OryBaseService } from '@getlarge/base-client-wrapper';
 import { Inject, Injectable } from '@nestjs/common';
-import { Configuration, RelationshipApi } from '@ory/client';
+import {
+  Configuration,
+  RelationshipApi,
+  RelationshipApiGetRelationshipsRequest,
+} from '@ory/client';
+import { RawAxiosRequestConfig } from 'axios';
 
 import { OryRelationshipsModuleOptions } from './ory-relationships.interfaces';
 
 @Injectable()
 export class OryRelationshipsService extends RelationshipApi {
+  readonly publicBasePath?: string;
+
   constructor(
     @Inject(OryRelationshipsModuleOptions)
     options: OryRelationshipsModuleOptions,
@@ -20,6 +27,7 @@ export class OryRelationshipsService extends RelationshipApi {
       baseService.axios as ConstructorParameters<typeof RelationshipApi>[2]
     );
 
+    this.publicBasePath = options.publicBasePath;
     this.configuration ??= new Configuration({
       basePath: options.basePath,
       accessToken: options.accessToken,
@@ -33,4 +41,14 @@ export class OryRelationshipsService extends RelationshipApi {
   set config(config: Configuration) {
     this.configuration = config;
   }
+
+  // enable URL override for getRelationships, it should use the Public API URL when using self-hosted Ory Keto
+  override getRelationships = (
+    requestParameters?: RelationshipApiGetRelationshipsRequest,
+    options: RawAxiosRequestConfig = {}
+  ) =>
+    super.getRelationships(requestParameters, {
+      ...options,
+      baseURL: this.publicBasePath ?? this.config.basePath,
+    });
 }


### PR DESCRIPTION
Enable override the public path to Ory Keto API.
This is not issue when using Ory Network but when working with self-hosted Ory Keto.